### PR TITLE
Add MHI initialisation option to init and add trltexx to build barrier

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -19,7 +19,7 @@ LOCAL_PATH := $(call my-dir)
 ifeq ($(BOARD_VENDOR),samsung)
 ifeq ($(TARGET_BOARD_PLATFORM),apq8084)
 
-ifneq ($(filter trlte trltetmo trltecan trltespr trlteusc,$(TARGET_DEVICE)),)
+ifneq ($(filter trlte trltexx trltetmo trltecan trltespr trlteusc,$(TARGET_DEVICE)),)
 include $(call all-subdir-makefiles,$(LOCAL_PATH))
 endif
 

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -1632,3 +1632,7 @@ on property:service.bootanim.exit=1
     write /proc/sys/net/ipv6/conf/rmnet_usb1/accept_ra 2
     write /proc/sys/net/ipv6/conf/rmnet_usb2/accept_ra 2
     write /proc/sys/net/ipv6/conf/rmnet_usb3/accept_ra 2
+
+# MHI
+on property:sys.modem.pipe=mhi
+    import init.qcom.mhi.rc

--- a/setup-makefiles.sh
+++ b/setup-makefiles.sh
@@ -230,7 +230,7 @@ EOF
 
 LOCAL_PATH := \$(call my-dir)
 
-ifneq (\$(filter trlte trltetmo trltespr trlteusc trltevzw,\$(TARGET_DEVICE)),)
+ifneq (\$(filter trlte trltexx trltetmo trltespr trlteusc trltevzw,\$(TARGET_DEVICE)),)
 
 include \$(CLEAR_VARS)
 LOCAL_MODULE := libmm-abl


### PR DESCRIPTION
On the trltexx we need to load the mhi driver module on a specific trigger. Using this commit setting the property 'sys.modem.pipe' to 'mhi' will result in importing init.qcom.mhi.rc (a file that exists in the trltexx device repo), which in turn will start 'mdm_helper' and insmod the module.

Plus the build barrier needs to be extended for the trltexx
